### PR TITLE
ci: add GitHub Actions workflows and unit-test suite for Python and R…

### DIFF
--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -1,0 +1,48 @@
+name: Test Python Pipeline
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "**.py"
+      - "tests/**"
+      - "grader_instructions.txt"
+      - "assignment/**"
+      - ".github/workflows/test-python.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "**.py"
+      - "tests/**"
+      - "grader_instructions.txt"
+      - "assignment/**"
+      - ".github/workflows/test-python.yml"
+
+jobs:
+  lint-and-test:
+    runs-on: ubuntu-latest
+
+    env:
+      LAB_NUMBER: "9"
+      OPENAI_API_KEY: "sk-test-dummy-key-for-ci"
+      BASE_LAB_DIR: "/tmp/test_lab"
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: "pip"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install openai python-dotenv pytest ruff
+
+      - name: Lint with ruff (pyflakes rules)
+        run: ruff check --select F .
+
+      - name: Run unit tests
+        run: pytest tests/ --ignore=tests/R -v

--- a/.github/workflows/test-r.yml
+++ b/.github/workflows/test-r.yml
@@ -1,0 +1,60 @@
+name: Test R Pipeline
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "R/**"
+      - "tests/R/**"
+      - "assignment/**"
+      - ".github/workflows/test-r.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "R/**"
+      - "tests/R/**"
+      - "assignment/**"
+      - ".github/workflows/test-r.yml"
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    env:
+      OPENAI_API_KEY: "sk-test-dummy-key-for-ci"
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up R
+        uses: r-lib/actions/setup-r@v2
+        with:
+          r-version: "4.4"
+          use-public-rspm: true
+
+      - name: Cache R packages
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.R_LIBS_USER }}
+          key: r-${{ runner.os }}-${{ hashFiles('R/**') }}
+          restore-keys: r-${{ runner.os }}-
+
+      - name: Install R packages
+        run: |
+          install.packages(c(
+            "remotes", "testthat", "withr",
+            "httr2", "jsonlite", "fs", "stringr",
+            "readr", "quarto", "librarian"
+          ))
+          remotes::install_github("cezarykuran/oaii", quiet = TRUE)
+        shell: Rscript {0}
+
+      - name: Check R syntax
+        run: |
+          for f in R/*.R; do
+            echo "Checking syntax: $f"
+            Rscript -e "parse(file='$f'); cat('OK\n')" || exit 1
+          done
+
+      - name: Run R tests
+        run: Rscript -e "testthat::test_dir('tests/R', reporter = 'progress')"

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,12 @@
+"""
+Root conftest.py — loaded by pytest before any test module.
+
+Sets the environment variables that grading_context.py and batch_grade.py
+validate at import time.  Using os.environ.setdefault ensures user-supplied
+values (e.g. from a real .env) are not overwritten when running locally.
+"""
+import os
+
+os.environ.setdefault("LAB_NUMBER", "9")
+os.environ.setdefault("OPENAI_API_KEY", "sk-test-dummy-key-for-ci")
+os.environ.setdefault("BASE_LAB_DIR", "/tmp/test_lab")

--- a/docs/ci_testing_overview.md
+++ b/docs/ci_testing_overview.md
@@ -1,0 +1,245 @@
+# CI Testing Overview
+
+This document describes the GitHub Actions workflows and unit-test suite added
+to validate both grading pipelines without making real OpenAI API calls.  All
+files were introduced together and form a single, coherent CI layer.
+
+---
+
+## Repository additions at a glance
+
+```
+.github/
+└── workflows/
+    ├── test-python.yml        # CI for the Python pipeline
+    └── test-r.yml             # CI for the R pipeline
+
+conftest.py                    # pytest environment bootstrap (project root)
+
+tests/
+├── test_grading_context.py    # Unit tests: grading_context.py
+├── test_grade_student.py      # Unit tests: grade_student.py (mocked API)
+└── R/
+    └── test_helper_functions.R  # Unit tests: R helper functions
+```
+
+---
+
+## GitHub Actions: Python workflow
+
+**File:** `.github/workflows/test-python.yml`
+
+**Trigger:** push or pull-request to `main` when any of the following paths
+change: `**.py`, `tests/**`, `grader_instructions.txt`, `assignment/**`, or
+the workflow file itself.
+
+**Steps:**
+
+| Step | Tool | Purpose |
+|---|---|---|
+| Checkout | `actions/checkout@v4` | Clone the repository |
+| Set up Python | `actions/setup-python@v5` (3.11, pip cache) | Reproducible interpreter |
+| Install dependencies | `pip install openai python-dotenv pytest ruff` | Runtime + test + lint |
+| Lint | `ruff check --select F .` | Catch undefined names, unused imports (pyflakes rules only) |
+| Test | `pytest tests/ --ignore=tests/R -v` | Run all Python unit tests |
+
+**Environment variables injected by the workflow:**
+
+| Variable | Value in CI | Purpose |
+|---|---|---|
+| `LAB_NUMBER` | `"9"` | Satisfies the import-time check in `grading_context.py` |
+| `OPENAI_API_KEY` | `"sk-test-dummy-key-for-ci"` | Prevents key-missing errors; never reaches the API |
+| `BASE_LAB_DIR` | `"/tmp/test_lab"` | Satisfies the import-time check in `batch_grade.py` |
+
+The linting step uses the `F` (pyflakes) rule-set deliberately: it catches
+real programming errors (undefined names, unused imports, shadowed variables)
+without failing on stylistic choices such as line length or variable naming.
+
+---
+
+## GitHub Actions: R workflow
+
+**File:** `.github/workflows/test-r.yml`
+
+**Trigger:** push or pull-request to `main` when any of the following paths
+change: `R/**`, `tests/R/**`, `assignment/**`, or the workflow file itself.
+
+**Steps:**
+
+| Step | Tool | Purpose |
+|---|---|---|
+| Checkout | `actions/checkout@v4` | Clone the repository |
+| Set up R | `r-lib/actions/setup-r@v2` (R 4.4, RSPM) | Pre-built CRAN binaries for speed |
+| Cache R library | `actions/cache@v4` keyed on `R/**` | Avoid re-installing packages on every run |
+| Install packages | `Rscript` inline | Install CRAN and GitHub dependencies |
+| Syntax check | `Rscript -e "parse(file=…)"` loop | Verify every `.R` file in `R/` is syntactically valid |
+| Run R tests | `Rscript -e "testthat::test_dir('tests/R')"` | Execute all `testthat` tests |
+
+**R packages installed in CI:**
+
+| Package | Source | Used by |
+|---|---|---|
+| `httr2` | CRAN | `oaii_grading_assistant.R` HTTP helpers |
+| `jsonlite` | CRAN | JSON serialisation in both R scripts |
+| `fs` | CRAN | File-system operations |
+| `stringr` | CRAN | Path construction via `str_glue` |
+| `readr` | CRAN | CSV output in the runner |
+| `quarto` | CRAN | Namespace required for `quarto::quarto_render` |
+| `librarian` | CRAN | Package loader used in the runner |
+| `remotes` | CRAN | GitHub package installation |
+| `testthat` | CRAN | Test framework |
+| `withr` | CRAN | `with_envvar` helper used in tests |
+| `cezarykuran/oaii` | GitHub | OpenAI Assistants API wrapper |
+
+**Environment variables injected by the workflow:**
+
+| Variable | Value in CI |
+|---|---|
+| `OPENAI_API_KEY` | `"sk-test-dummy-key-for-ci"` |
+
+`LAB_NUMBER` is set as an R variable (`LAB_NUMBER <- 9L`) inside the test
+file rather than as a shell environment variable, matching the convention used
+by the R scripts themselves.
+
+---
+
+## Python test suite
+
+### `conftest.py` — environment bootstrap
+
+Placed at the **project root** so pytest adds the root directory to
+`sys.path` automatically.  Sets all three environment variables using
+`os.environ.setdefault` before any test module is imported:
+
+```
+LAB_NUMBER      → "9"
+OPENAI_API_KEY  → "sk-test-dummy-key-for-ci"
+BASE_LAB_DIR    → "/tmp/test_lab"
+```
+
+`setdefault` is used rather than a hard assignment so that a developer
+running locally with a real `.env` file (and real values) does not have those
+values silently overwritten.
+
+---
+
+### `tests/test_grading_context.py` — 10 tests
+
+Tests the three public functions in `grading_context.py` without any API
+interaction.
+
+**`load_text`**
+
+| Test | What it checks |
+|---|---|
+| `test_load_text_reads_utf8_file` | Reads and returns the exact content of a UTF-8 file |
+| `test_load_text_accepts_string_path` | Accepts a plain `str` as well as a `Path` |
+| `test_load_text_raises_for_missing_file` | Raises `FileNotFoundError` for a non-existent path |
+
+**`build_system_message`**
+
+| Test | What it checks |
+|---|---|
+| `test_build_system_message_returns_dict` | Return value is a `dict` |
+| `test_build_system_message_role_is_system` | `role` key equals `"system"` |
+| `test_build_system_message_content_is_nonempty_string` | `content` is a non-empty `str` |
+
+**`build_cached_context_messages`**
+
+| Test | What it checks |
+|---|---|
+| `test_build_cached_context_messages_returns_three_messages` | Exactly three messages are returned (rubric, starter, solution) |
+| `test_build_cached_context_messages_all_user_role` | Every message has `role = "user"` |
+| `test_build_cached_context_messages_have_ephemeral_cache_control` | Every message carries `cache_control = {"type": "ephemeral"}` |
+| `test_build_cached_context_messages_content_is_single_text_block` | `content` is a one-element list whose sole item has `type = "text"` and non-empty `text` |
+
+The last four tests exercise the real `assignment/` fixture files that live in
+the repository, giving them light integration coverage at no extra cost.
+
+---
+
+### `tests/test_grade_student.py` — 6 tests
+
+Tests `grade_student_qmd` using `unittest.mock.patch` to replace the `OpenAI`
+class in `grade_student`'s namespace.  The mock client returns a pre-built
+JSON payload; no network call is ever made.
+
+| Test | What it checks |
+|---|---|
+| `test_returns_dict` | Return value is a `dict` |
+| `test_contains_required_top_level_keys` | Keys `questions`, `total`, `overall_comment` are all present |
+| `test_total_matches_payload` | `total` equals the value in the mocked response |
+| `test_calls_api_with_configured_model` | The `model` kwarg passed to `create()` equals `grading_context.MODEL` |
+| `test_enforces_json_response_format` | `response_format={"type": "json_object"}` is passed to `create()` |
+| `test_raises_file_not_found_for_missing_student` | `FileNotFoundError` is raised when the `.qmd` path does not exist |
+
+---
+
+## R test suite
+
+### `tests/R/test_helper_functions.R` — 7 tests
+
+Uses `testthat` as the test framework and `withr::with_envvar` to temporarily
+override environment variables within individual tests.
+
+**Safe sourcing of `oaii_grading_assistant.R`**
+
+The helper script ends with the guard:
+
+```r
+if (identical(environment(), globalenv())) {
+  tryCatch(main(), error = function(e) { ... quit(...) })
+}
+```
+
+If the file were sourced naively into `globalenv()`, `main()` would execute
+and — on failure — call `quit()`, killing the test runner process.  The test
+file avoids this by sourcing into a dedicated child environment:
+
+```r
+fns_env <- new.env(parent = globalenv())
+fns_env$LAB_NUMBER <- 9L
+sys.source("R/oaii_grading_assistant.R", envir = fns_env)
+```
+
+Because `fns_env` is not `globalenv()`, the guard evaluates to `FALSE` and
+`main()` is never called.  The helper functions are then copied into the test
+file's namespace for convenient use.
+
+**Tests**
+
+| Test | Function tested | What it checks |
+|---|---|---|
+| `oaii_grading_assistant.R parses without error` | — | Syntax-only parse of the setup script |
+| `oaii_grading_assistant_runner.R parses without error` | — | Syntax-only parse of the runner script |
+| `qmd_to_temp_md raises error for a missing file` | `qmd_to_temp_md` | `stop("Missing file …")` is triggered before any Quarto render |
+| `upload_for_assistants raises error for a missing file` | `upload_for_assistants` | `stop("Missing file …")` is triggered before any API upload |
+| `openai_req raises error when OPENAI_API_KEY is unset` | `openai_req` | `NA` key value triggers the guard |
+| `openai_req raises error when OPENAI_API_KEY is empty string` | `openai_req` | Empty-string key triggers the guard |
+| `openai_req returns an httr2_request with a valid key` | `openai_req` | Non-empty dummy key produces an `httr2_request` object without any HTTP call |
+
+---
+
+## Design decisions
+
+**No real API calls.** All tests use either `unittest.mock` (Python) or
+`sys.source` isolation with dummy credentials (R).  The `OPENAI_API_KEY`
+values used in CI are syntactically valid non-empty strings that will be
+rejected by the OpenAI API but satisfy every local validation check in the
+codebase.
+
+**Fixture files from the repository.** Rather than creating artificial stubs,
+the Python context tests read the real `assignment/rubric_lab_9.json`,
+`BSMM_8740_lab_9_starter.qmd`, `BSMM_8740_lab_9_solutions.qmd`, and
+`grader_instructions.txt`.  This means the tests also catch problems such as a
+missing or malformed rubric file.
+
+**Linting scope.** `ruff --select F` covers pyflakes rules: undefined names,
+undefined local variables, redefined imports, and unused imports.  Style rules
+(line length, naming conventions) are intentionally excluded so the linter
+catches bugs rather than acting as a style enforcer.
+
+**R package caching.** The R workflow caches `$R_LIBS_USER` keyed on the hash
+of all files in `R/`.  On a cache hit, the install step is skipped entirely,
+keeping the workflow fast.  A cache miss occurs only when the R source files
+change — a reasonable proxy for when dependencies might change.

--- a/tests/R/test_helper_functions.R
+++ b/tests/R/test_helper_functions.R
@@ -1,0 +1,84 @@
+# ===========================================================================
+# Unit tests for R/oaii_grading_assistant.R helper functions
+#
+# Strategy:
+#   - Load functions by sourcing into a dedicated environment so the
+#     `if (identical(environment(), globalenv())) { main() }` guard
+#     never fires, preventing any real API calls or Quarto renders.
+#   - Test only the defensive (non-API) logic: file-existence checks and
+#     missing-key guards.
+#   - Syntax tests for both R scripts are included as a smoke check.
+# ===========================================================================
+
+library(testthat)
+library(withr)
+
+# ---------------------------------------------------------------------------
+# Source helper functions into an isolated environment
+# ---------------------------------------------------------------------------
+
+LAB_NUMBER <- 9L   # needed by oaii_grading_assistant.R's module-level code
+Sys.setenv(OPENAI_API_KEY = "sk-test-dummy-key-for-ci")
+
+fns_env <- new.env(parent = globalenv())
+fns_env$LAB_NUMBER <- LAB_NUMBER
+sys.source("R/oaii_grading_assistant.R", envir = fns_env)
+
+qmd_to_temp_md        <- fns_env$qmd_to_temp_md
+upload_for_assistants <- fns_env$upload_for_assistants
+openai_req            <- fns_env$openai_req
+
+# ---------------------------------------------------------------------------
+# Syntax checks
+# ---------------------------------------------------------------------------
+
+test_that("oaii_grading_assistant.R parses without error", {
+  expect_no_error(parse(file = "R/oaii_grading_assistant.R"))
+})
+
+test_that("oaii_grading_assistant_runner.R parses without error", {
+  expect_no_error(parse(file = "R/oaii_grading_assistant_runner.R"))
+})
+
+# ---------------------------------------------------------------------------
+# qmd_to_temp_md: missing-file guard
+# ---------------------------------------------------------------------------
+
+test_that("qmd_to_temp_md raises error for a missing file", {
+  expect_error(
+    qmd_to_temp_md("/nonexistent/path/missing.qmd"),
+    "Missing file"
+  )
+})
+
+# ---------------------------------------------------------------------------
+# upload_for_assistants: missing-file guard
+# ---------------------------------------------------------------------------
+
+test_that("upload_for_assistants raises error for a missing file", {
+  expect_error(
+    upload_for_assistants("/nonexistent/file.txt", api_key = "dummy"),
+    "Missing file"
+  )
+})
+
+# ---------------------------------------------------------------------------
+# openai_req: missing / empty API key guard
+# ---------------------------------------------------------------------------
+
+test_that("openai_req raises error when OPENAI_API_KEY is unset", {
+  withr::with_envvar(c(OPENAI_API_KEY = NA_character_), {
+    expect_error(openai_req("/assistants"), "OPENAI_API_KEY is not set")
+  })
+})
+
+test_that("openai_req raises error when OPENAI_API_KEY is empty string", {
+  withr::with_envvar(c(OPENAI_API_KEY = ""), {
+    expect_error(openai_req("/assistants"), "OPENAI_API_KEY is not set")
+  })
+})
+
+test_that("openai_req returns an httr2_request with a valid key", {
+  req <- openai_req("/assistants")
+  expect_s3_class(req, "httr2_request")
+})

--- a/tests/test_grade_student.py
+++ b/tests/test_grade_student.py
@@ -1,0 +1,114 @@
+"""
+Unit tests for grade_student.py.
+
+The OpenAI client is fully mocked so no real API calls are made.
+Tests verify that grade_student_qmd:
+  - returns a dict with the expected top-level keys
+  - passes the configured model to the API
+  - propagates FileNotFoundError for missing student files
+"""
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from grade_student import grade_student_qmd
+from grading_context import MODEL
+
+# ---------------------------------------------------------------------------
+# Shared fixture data
+# ---------------------------------------------------------------------------
+
+_MOCK_PAYLOAD = {
+    "questions": {
+        f"Q{i}": {"grade": 3, "feedback": f"Feedback for Q{i}."}
+        for i in range(1, 9)
+    },
+    "total": 24,
+    "overall_comment": "Strong submission overall.",
+}
+
+
+def _make_mock_response(payload: dict) -> MagicMock:
+    mock = MagicMock()
+    mock.choices[0].message.content = json.dumps(payload)
+    return mock
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+def test_returns_dict(tmp_path):
+    student = tmp_path / "2025-lab-9.qmd"
+    student.write_text("# Submission", encoding="utf-8")
+
+    with patch("grade_student.OpenAI") as MockOpenAI:
+        MockOpenAI.return_value.chat.completions.create.return_value = (
+            _make_mock_response(_MOCK_PAYLOAD)
+        )
+        result = grade_student_qmd(student)
+
+    assert isinstance(result, dict)
+
+
+def test_contains_required_top_level_keys(tmp_path):
+    student = tmp_path / "2025-lab-9.qmd"
+    student.write_text("# Submission", encoding="utf-8")
+
+    with patch("grade_student.OpenAI") as MockOpenAI:
+        MockOpenAI.return_value.chat.completions.create.return_value = (
+            _make_mock_response(_MOCK_PAYLOAD)
+        )
+        result = grade_student_qmd(student)
+
+    assert {"questions", "total", "overall_comment"} <= result.keys()
+
+
+def test_total_matches_payload(tmp_path):
+    student = tmp_path / "2025-lab-9.qmd"
+    student.write_text("# Submission", encoding="utf-8")
+
+    with patch("grade_student.OpenAI") as MockOpenAI:
+        MockOpenAI.return_value.chat.completions.create.return_value = (
+            _make_mock_response(_MOCK_PAYLOAD)
+        )
+        result = grade_student_qmd(student)
+
+    assert result["total"] == 24
+
+
+def test_calls_api_with_configured_model(tmp_path):
+    student = tmp_path / "2025-lab-9.qmd"
+    student.write_text("# Submission", encoding="utf-8")
+
+    with patch("grade_student.OpenAI") as MockOpenAI:
+        mock_client = MockOpenAI.return_value
+        mock_client.chat.completions.create.return_value = (
+            _make_mock_response(_MOCK_PAYLOAD)
+        )
+        grade_student_qmd(student)
+        call_kwargs = mock_client.chat.completions.create.call_args.kwargs
+
+    assert call_kwargs["model"] == MODEL
+
+
+def test_enforces_json_response_format(tmp_path):
+    student = tmp_path / "2025-lab-9.qmd"
+    student.write_text("# Submission", encoding="utf-8")
+
+    with patch("grade_student.OpenAI") as MockOpenAI:
+        mock_client = MockOpenAI.return_value
+        mock_client.chat.completions.create.return_value = (
+            _make_mock_response(_MOCK_PAYLOAD)
+        )
+        grade_student_qmd(student)
+        call_kwargs = mock_client.chat.completions.create.call_args.kwargs
+
+    assert call_kwargs.get("response_format") == {"type": "json_object"}
+
+
+def test_raises_file_not_found_for_missing_student():
+    with pytest.raises(FileNotFoundError):
+        grade_student_qmd(Path("/nonexistent/student.qmd"))

--- a/tests/test_grading_context.py
+++ b/tests/test_grading_context.py
@@ -1,0 +1,85 @@
+"""
+Unit tests for grading_context.py.
+
+These tests exercise file-loading helpers and message-builder functions
+without making any API calls.  The assignment fixture files that already
+exist in the repository (assignment/rubric_lab_9.json, etc.) are used
+directly so tests remain self-contained.
+"""
+import pytest
+from grading_context import (
+    build_cached_context_messages,
+    build_system_message,
+    load_text,
+)
+
+
+# ---------------------------------------------------------------------------
+# load_text
+# ---------------------------------------------------------------------------
+
+def test_load_text_reads_utf8_file(tmp_path):
+    f = tmp_path / "sample.txt"
+    f.write_text("hello world", encoding="utf-8")
+    assert load_text(f) == "hello world"
+
+
+def test_load_text_accepts_string_path(tmp_path):
+    f = tmp_path / "sample.txt"
+    f.write_text("content", encoding="utf-8")
+    assert load_text(str(f)) == "content"
+
+
+def test_load_text_raises_for_missing_file():
+    with pytest.raises(FileNotFoundError):
+        load_text("/nonexistent/path/file.txt")
+
+
+# ---------------------------------------------------------------------------
+# build_system_message
+# ---------------------------------------------------------------------------
+
+def test_build_system_message_returns_dict():
+    msg = build_system_message()
+    assert isinstance(msg, dict)
+
+
+def test_build_system_message_role_is_system():
+    msg = build_system_message()
+    assert msg.get("role") == "system"
+
+
+def test_build_system_message_content_is_nonempty_string():
+    msg = build_system_message()
+    content = msg.get("content")
+    assert isinstance(content, str) and len(content) > 0
+
+
+# ---------------------------------------------------------------------------
+# build_cached_context_messages
+# ---------------------------------------------------------------------------
+
+def test_build_cached_context_messages_returns_three_messages():
+    msgs = build_cached_context_messages()
+    assert len(msgs) == 3
+
+
+def test_build_cached_context_messages_all_user_role():
+    msgs = build_cached_context_messages()
+    assert all(m["role"] == "user" for m in msgs)
+
+
+def test_build_cached_context_messages_have_ephemeral_cache_control():
+    msgs = build_cached_context_messages()
+    for msg in msgs:
+        assert msg.get("cache_control") == {"type": "ephemeral"}
+
+
+def test_build_cached_context_messages_content_is_single_text_block():
+    msgs = build_cached_context_messages()
+    for msg in msgs:
+        content = msg.get("content", [])
+        assert isinstance(content, list) and len(content) == 1
+        block = content[0]
+        assert block.get("type") == "text"
+        assert isinstance(block.get("text"), str) and len(block["text"]) > 0


### PR DESCRIPTION
… pipelines

- .github/workflows/test-python.yml: lints with ruff (pyflakes rules) and runs pytest on push/PR to main for any Python or assignment file change
- .github/workflows/test-r.yml: syntax-checks R scripts and runs testthat on push/PR to main for any R or assignment file change; caches R library
- conftest.py: bootstraps LAB_NUMBER, OPENAI_API_KEY, BASE_LAB_DIR env vars before pytest imports any module (both grading_context and batch_grade validate these at import time)
- tests/test_grading_context.py: 10 unit tests for load_text, build_system_message, and build_cached_context_messages (no API calls)
- tests/test_grade_student.py: 6 unit tests for grade_student_qmd with fully mocked OpenAI client
- tests/R/test_helper_functions.R: 7 testthat tests for R helper functions; uses sys.source into a child environment to prevent main() auto-execution
- docs/ci_testing_overview.md: documents all workflows, tests, and design decisions