### PR TITLE
ci: opt in to Node.js 24 for GitHub Actions runners

### DIFF
--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -26,6 +26,7 @@ jobs:
       LAB_NUMBER: "9"
       OPENAI_API_KEY: "sk-test-dummy-key-for-ci"
       BASE_LAB_DIR: "/tmp/test_lab"
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test-r.yml
+++ b/.github/workflows/test-r.yml
@@ -22,6 +22,7 @@ jobs:
 
     env:
       OPENAI_API_KEY: "sk-test-dummy-key-for-ci"
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Adds FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true to the env block of both workflows to silence the Node.js 20 deprecation warning ahead of the June 2026 forced migration deadline.