### PR TITLE
Make R/Python pipelines a controlled comparison

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,7 +138,7 @@ Two GitHub Actions workflows with path-based triggers:
 
 ## Models
 
-- R runner: `gpt-4.1-mini` (set in `R/oaii_grading_assistant.R`)
+- R runner: `gpt-5.1`, `temperature = 0.1` (set in `R/oaii_grading_assistant.R` and `start_run()` in `R/oaii_grading_assistant_runner.R`)
 - Python: `gpt-5.1` (set in `Python/grading_context.py`)
 
 ---

--- a/R/oaii_grading_assistant.R
+++ b/R/oaii_grading_assistant.R
@@ -10,6 +10,8 @@
 # install.packages("oaii")   # if needed
 
 # ---- config ----
+MODEL <- "gpt-5.1"
+
 # ---- paths ----
 RUBRIC_PATH  <- stringr::str_glue("./assignment/rubric_lab_{LAB_NUMBER}.json")
 SOLUTION_QMD <- stringr::str_glue("./assignment/lab_{LAB_NUMBER}_solutions.qmd")
@@ -145,33 +147,74 @@ create_assistant_v2 <- function(model, name = NULL, instructions = NULL, tools =
   httr2::resp_body_json(resp, simplifyVector = TRUE)
 }
 
+#' Check whether a valid assistant config exists for the given model
+#'
+#' Reads \code{assistant_config.json} and returns \code{TRUE} only when the
+#' file exists, can be parsed as JSON, contains non-empty values for all
+#' required fields (\code{assistant_id}, \code{rubric_file_id},
+#' \code{solution_file_id}, \code{starter_file_id}, \code{model}), and the
+#' stored \code{model} matches \code{expected_model}. Any parse error returns
+#' \code{FALSE} silently.
+#'
+#' @param config_path Character. Path to \code{assistant_config.json}.
+#' @param expected_model Character. The model ID the current session requires,
+#'   e.g. \code{"gpt-5.1"}. A mismatch causes the function to return
+#'   \code{FALSE}, triggering a fresh setup with the correct model.
+#'
+#' @returns Logical scalar. \code{TRUE} if the config is present, complete, and
+#'   matches \code{expected_model}; \code{FALSE} otherwise.
+#'
+#' @seealso \code{\link{main}}
+config_is_valid <- function(config_path, expected_model) {
+  if (!fs::file_exists(config_path)) return(FALSE)
+  cfg <- tryCatch(
+    jsonlite::read_json(config_path),
+    error = function(e) NULL
+  )
+  if (is.null(cfg)) return(FALSE)
+  required <- c("assistant_id", "rubric_file_id", "solution_file_id",
+                "starter_file_id", "model")
+  has_all <- all(vapply(required, function(k) {
+    v <- cfg[[k]]
+    !is.null(v) && nzchar(as.character(v))
+  }, logical(1L)))
+  has_all && identical(cfg[["model"]], expected_model)
+}
+
 #' Set up the OpenAI grading assistant for a lab
 #'
-#' Orchestrates the one-time setup required before batch grading can begin.
-#' Specifically: renders the solution and starter \code{.qmd} files to GitHub
-#' Flavored Markdown, uploads the rubric, rendered solution, and rendered
-#' starter to the OpenAI Files API, creates an Assistants v2 assistant
+#' Orchestrates the setup required before batch grading can begin. If a valid
+#' \code{assistant_config.json} already exists for the current \code{MODEL},
+#' setup is skipped entirely and the function returns invisibly — preventing
+#' redundant file uploads and assistant creation on repeated runs. When setup
+#' is needed, the function: renders the solution and starter \code{.qmd} files
+#' to GitHub Flavored Markdown, uploads the rubric, rendered solution, and
+#' rendered starter to the OpenAI Files API, creates an Assistants v2 assistant
 #' configured with the \code{file_search} tool, and persists the resulting IDs
-#' to \code{assistant_config.json} for consumption by the runner script
-#' (\code{oaii_grading_assistant_runner.R}).
+#' (plus the model name) to \code{assistant_config.json}.
 #'
 #' Reads file paths from the module-level constants \code{RUBRIC_PATH},
-#' \code{SOLUTION_QMD}, \code{STARTER_FILE}, and \code{CONFIG_JSON}, which are
-#' constructed from the \code{LAB_NUMBER} variable set before sourcing this
-#' file.
+#' \code{SOLUTION_QMD}, \code{STARTER_FILE}, \code{CONFIG_JSON}, and
+#' \code{MODEL}, which are set at the top of this file.
 #'
 #' @returns Called for its side effects. Returns \code{NULL} invisibly.
 #'   Writes \code{assistant_config.json} containing \code{assistant_id},
-#'   \code{rubric_file_id}, \code{solution_file_id}, and
-#'   \code{starter_file_id}. Emits progress messages via \code{message()}.
+#'   \code{rubric_file_id}, \code{solution_file_id}, \code{starter_file_id},
+#'   and \code{model}. Emits progress messages via \code{message()}.
 #'
-#' @seealso \code{\link{qmd_to_temp_md}}, \code{\link{upload_for_assistants}},
-#'   \code{\link{create_assistant_v2}}
+#' @seealso \code{\link{config_is_valid}}, \code{\link{qmd_to_temp_md}},
+#'   \code{\link{upload_for_assistants}}, \code{\link{create_assistant_v2}}
 # ---- main ----
 main <- function() {
   # ensure key present
   key <- Sys.getenv("OPENAI_API_KEY", unset = NA_character_)
   if (is.na(key) || !nzchar(key)) stop("OPENAI_API_KEY is not set.")
+
+  # skip setup if a valid config already exists for this model
+  if (config_is_valid(CONFIG_JSON, MODEL)) {
+    message("Valid assistant config found for model ", MODEL, ". Skipping setup.")
+    return(invisible(NULL))
+  }
 
   # render solution to GFM
   solution_md <- qmd_to_temp_md(SOLUTION_QMD)
@@ -182,22 +225,9 @@ main <- function() {
   solution_file <- upload_for_assistants(solution_md, api_key = key)
   starter_file  <- upload_for_assistants(starter_md, api_key = key)
 
-  # # create assistant with file_search tool
-  # assistant <- oaii::assistants_create_assistant_request(
-  #   model        = "gpt-4.1-mini",
-  #   name         = "BSMM 8740 Lab 3 Grading Assistant",
-  #   instructions = paste0(
-  #     "You grade lab submissions using the rubric and the rendered solution. ",
-  #     "Search attached files and cite sources where helpful."
-  #   ),
-  #   tools        = list(list(type = "file_search")),
-  #   file_ids     = NULL,
-  #   api_key      = key
-  # )
-
-  # create assistantwith file_search tool
+  # create assistant with file_search tool
   assistant <- create_assistant_v2(
-    model        = "gpt-4.1-mini",
+    model        = MODEL,
     name         = "BSMM 8740 Lab 9 Grading Assistant",
     instructions = paste0(
       "You grade lab submissions using the rubric and the rendered solution. ",
@@ -206,12 +236,13 @@ main <- function() {
     tools        = list(list(type = "file_search"))
   )
 
-  # persist IDs
+  # persist IDs and model
   cfg <- list(
     assistant_id      = assistant$id,
     rubric_file_id    = rubric_file$id,
     solution_file_id  = solution_file$id,
-    starter_file_id   = starter_file$id
+    starter_file_id   = starter_file$id,
+    model             = MODEL
   )
 
   jsonlite::write_json(cfg, CONFIG_JSON, pretty = TRUE, auto_unbox = TRUE)

--- a/R/oaii_grading_assistant_runner.R
+++ b/R/oaii_grading_assistant_runner.R
@@ -111,13 +111,15 @@ add_message <- function(thread_id, content, role = "user", attachments = NULL) {
 #'
 #' @returns A named list representing the run object, including at minimum
 #'   \code{$id} (the run ID) and \code{$status} (initially \code{"queued"} or
-#'   \code{"in_progress"}).
+#'   \code{"in_progress"}). The run is configured with \code{temperature = 0.1}
+#'   to match the Python pipeline and minimise grading variability.
 #'
 #' @examples
 start_run <- function(thread_id, assistant_id) {
   body <- list(
     assistant_id    = assistant_id,
-    response_format = list(type = "json_object")
+    response_format = list(type = "json_object"),
+    temperature     = 0.1
   )
   resp <- openai_req(sprintf("/threads/%s/runs", thread_id)) |>
     httr2::req_headers("Content-Type" = "application/json") |>

--- a/docs/pipeline_comparison.md
+++ b/docs/pipeline_comparison.md
@@ -13,11 +13,13 @@ and how much infrastructure must be in place before grading can begin.
 |---|---|---|
 | **API** | Chat Completions (`POST /chat/completions`) | Assistants v2 (`/assistants`, `/threads`, `/runs`) |
 | **Execution model** | Synchronous — one HTTP call per student | Asynchronous — thread created, run started, then polled |
-| **Setup required** | None — stateless, run directly | One-time setup script creates a persistent Assistant and uploads files |
+| **Setup required** | None — stateless, run directly | Runs automatically on first use; skipped on subsequent runs if `assistant_config.json` is present and matches the current model |
 | **Context delivery** | Full rubric, solution, and starter inlined in every request | Files uploaded once; model retrieves relevant chunks via `file_search` |
 | **Caching** | Ephemeral prompt caching on the shared prefix | Persistent file storage on OpenAI servers |
-| **Structured output** | Enforced via `response_format={"type": "json_object"}` | Requested via prompt only; no API-level enforcement |
-| **Output parsing** | Single `json.loads()` call | Multi-schema defensive parser (`parse_reply_to_row`) |
+| **Structured output** | Enforced via `response_format={"type": "json_object"}` | Enforced via `response_format = list(type = "json_object")` in `start_run()` |
+| **Output parsing** | Single `json.loads()` call | Single `jsonlite::fromJSON()` call |
+| **Temperature** | `0.1` | `0.1` |
+| **Model** | `gpt-5.1` | `gpt-5.1` |
 | **Scripts** | 3 modules (`grading_context.py`, `grade_student.py`, `batch_grade.py`) | 2 scripts (`oaii_grading_assistant.R`, `oaii_grading_assistant_runner.R`) |
 | **CSV encoding** | UTF-8 | UTF-8 BOM (Excel compatible) |
 
@@ -32,11 +34,11 @@ fit within a single call — and a hard dependency on cache hit rates for cost
 efficiency at scale.
 
 The R pipeline offloads grading materials to OpenAI's file storage, keeping
-per-call payloads small and enabling the same Assistant to serve repeated
-grading sessions without re-uploading. The cost is operational complexity: the
-two-script workflow, asynchronous polling, and the absence of structured output
-enforcement mean the R code requires substantially more defensive logic —
-particularly in `parse_reply_to_row`, which handles three possible JSON schemas
-the model might return. Adopting `response_format` on the run object (available
-in Assistants v2) would bring the R pipeline to parity with Python on output
-reliability.
+per-call payloads small. The setup phase (file upload, assistant creation) runs
+automatically on first use and is skipped on subsequent runs via a config cache
+keyed on model name. The cost is operational complexity: the two-script
+workflow and asynchronous polling require more infrastructure than the Python
+approach. Both pipelines now use the same model (`gpt-5.1`), temperature
+(`0.1`), and API-enforced JSON output (`response_format = json_object`), so
+the remaining differences — Assistants v2 vs Chat Completions, and file
+retrieval vs inline context — are the variables under study.

--- a/docs/session_notes_2026_03_30.md
+++ b/docs/session_notes_2026_03_30.md
@@ -1,0 +1,95 @@
+# Session Notes — 2026-03-30
+
+## Objective
+
+Make the R and Python pipelines a controlled comparison by eliminating
+confounding variables (model, temperature), and fix a latent bug where the
+R setup phase ran on every invocation, accumulating orphaned OpenAI assets.
+
+---
+
+## Background
+
+The two pipelines were observed to produce different grades for the same
+student submissions. The hypothesis was that the Assistants v2 architecture
+used by the R pipeline is inherently less reliable than the Chat Completions
+approach used by Python. Investigation identified three confounds that made
+this hypothesis untestable:
+
+| Confound | R (before) | Python |
+|---|---|---|
+| Model | `gpt-4.1-mini` | `gpt-5.1` |
+| Temperature | unset (API default ~1.0) | `0.1` |
+| Context delivery | `file_search` retrieval | inline with prompt caching |
+
+Context delivery is the paradigm under study and was left intentionally
+different. Model and temperature were unintended confounds and have been
+corrected.
+
+---
+
+## Changes made
+
+### 1. Matched model: `R/oaii_grading_assistant.R`
+
+- Added module-level constant `MODEL <- "gpt-5.1"`.
+- Replaced the hardcoded `"gpt-4.1-mini"` string in `create_assistant_v2()`
+  with `MODEL`.
+
+### 2. Matched temperature: `R/oaii_grading_assistant_runner.R`
+
+- Added `temperature = 0.1` to the request body in `start_run()`, matching
+  the Python pipeline's `temperature=0.1` in `grade_student.py`.
+- Updated `start_run()` Roxygen `@returns` to document the temperature setting.
+
+### 3. Skip-setup guard: `R/oaii_grading_assistant.R`
+
+**Problem:** The runner calls `source("./R/oaii_grading_assistant.R")` at the
+top level, which executes in the global environment and therefore triggers the
+`if (identical(environment(), globalenv()))` guard, running `main()` on every
+invocation. This created a new assistant and uploaded three files on every
+grading run, accumulating orphaned assets in the OpenAI account and adding
+unnecessary latency and storage cost.
+
+**Fix:** Added `config_is_valid()` helper and a skip guard at the top of
+`main()`.
+
+`config_is_valid(config_path, expected_model)` returns `TRUE` only when:
+- `assistant_config.json` exists and parses without error,
+- all required fields (`assistant_id`, `rubric_file_id`, `solution_file_id`,
+  `starter_file_id`, `model`) are present and non-empty, and
+- the stored `model` matches `expected_model`.
+
+The model check ensures that changing `MODEL` automatically triggers a fresh
+setup, preventing the pipeline from grading with an assistant backed by the
+wrong model.
+
+`main()` now stores `model = MODEL` in `assistant_config.json` so future
+invocations can compare against it.
+
+To force re-setup (e.g. after changing the rubric or solution), delete
+`assignment/assistant_config.json`.
+
+---
+
+## Files changed
+
+| File | Change |
+|---|---|
+| `R/oaii_grading_assistant.R` | Added `MODEL` constant; added `config_is_valid()`; updated `main()` to skip setup when valid config exists; stores `model` in config |
+| `R/oaii_grading_assistant_runner.R` | Added `temperature = 0.1` to `start_run()` body; updated Roxygen |
+| `docs/pipeline_comparison.md` | Updated table and trade-offs to reflect current state |
+| `CLAUDE.md` | Updated Models section |
+
+---
+
+## Remaining intentional differences between pipelines
+
+| Aspect | R | Python |
+|---|---|---|
+| API | Assistants v2 | Chat Completions |
+| Context delivery | `file_search` retrieval | Inline with ephemeral caching |
+| Output CSV | Single `Comments` column, UTF-8 BOM | Separate `Q*_feedback` columns, UTF-8 |
+
+These differences are the subject of the comparison, not confounds to be
+eliminated.


### PR DESCRIPTION
- Match model: gpt-4.1-mini -> gpt-5.1 in R setup script (MODEL constant)
- Match temperature: add temperature=0.1 to start_run() in R runner
- Add config_is_valid() guard to skip assistant setup when a valid assistant_config.json already exists for the current model, preventing orphaned asset accumulation on repeated runs; model stored in config so a model change automatically triggers fresh setup
- Update docs: pipeline_comparison.md, session_notes_2026_03_30.md, CLAUDE.md