### PR TITLE
docs: update documentation for new R pipelines and reliability testing

### DIFF
--- a/docs/ci_testing_overview.md
+++ b/docs/ci_testing_overview.md
@@ -71,7 +71,7 @@ change: `R/**`, `tests/R/**`, `assignment/**`, or the workflow file itself.
 | Set up R | `r-lib/actions/setup-r@v2` (R 4.4, RSPM) | Pre-built CRAN binaries for speed |
 | Cache R library | `actions/cache@v4` keyed on `R/**` | Avoid re-installing packages on every run |
 | Install packages | `Rscript` inline | Install CRAN and GitHub dependencies |
-| Syntax check | `Rscript -e "parse(file=…)"` loop | Verify every `.R` file in `R/` is syntactically valid |
+| Syntax check | `Rscript -e "parse(file=…)"` loop | Verify every `.R` file in `R/` is syntactically valid — covers `oaii_grading_assistant.R`, `oaii_grading_assistant_runner.R`, `chat_grading_runner.R`, `reliability_test.R`, `aggregate_results.R`, and `utils.R` |
 | Run R tests | `Rscript -e "testthat::test_dir('tests/R')"` | Execute all `testthat` tests |
 
 **R packages installed in CI:**

--- a/docs/pipeline_comparison.md
+++ b/docs/pipeline_comparison.md
@@ -4,49 +4,53 @@ editor_options:
     wrap: 72
 ---
 
-# Automated Grading Pipeline: R vs Python Comparison
+# Automated Grading Pipelines: Comparison
 
-Both pipelines automate the LLM-based grading of student Quarto (`.qmd`)
-lab submissions and produce a CSV of per-question grades and feedback.
-They share the same high-level goal and the same grading materials — a
-JSON rubric, an instructor solution, and a starter template — but differ
-fundamentally in which OpenAI API they target, how grading context is
-delivered to the model, and how much infrastructure must be in place
-before grading can begin.
+Three pipelines automate the LLM-based grading of student Quarto (`.qmd`) lab
+submissions and produce a CSV of per-question grades and feedback. They share
+the same high-level goal and the same grading materials — a JSON rubric, an
+instructor solution, and a starter template — but differ in which OpenAI API
+they target, how grading context is delivered to the model, and how much
+infrastructure must be in place before grading can begin.
+
+The primary comparison in the JOSE paper is **Python vs R (Assistants v2)**.
+The **R (Chat Completions)** pipeline is a direct R port of the Python approach
+and serves to confirm that observed differences are attributable to the API
+choice rather than the programming language.
 
 ## Structural Differences
 
-| Aspect | Python | R |
-|------------------------|------------------------|------------------------|
-| **API** | Chat Completions (`POST /chat/completions`) | Assistants v2 (`/assistants`, `/threads`, `/runs`) |
-| **Execution model** | Synchronous — one HTTP call per student | Asynchronous — thread created, run started, then polled |
-| **Setup required** | None — stateless, run directly | Runs automatically on first use; skipped on subsequent runs if `assistant_config.json` is present and matches the current model |
-| **Context delivery** | Full rubric, solution, and starter inlined in every request | Files uploaded once; model retrieves relevant chunks via `file_search` |
-| **Caching** | Ephemeral prompt caching on the shared prefix | Persistent file storage on OpenAI servers |
-| **Structured output** | Enforced via `response_format={"type": "json_object"}` | Enforced via `response_format = list(type = "json_object")` in `start_run()` |
-| **Output parsing** | Single `json.loads()` call | Single `jsonlite::fromJSON()` call |
-| **Temperature** | `0.1` | `0.1` |
-| **Model** | `gpt-5.1` | `gpt-5.1` |
-| **Scripts** | 3 modules (`grading_context.py`, `grade_student.py`, `batch_grade.py`) | 2 scripts (`oaii_grading_assistant.R`, `oaii_grading_assistant_runner.R`) |
-| **CSV encoding** | UTF-8 | UTF-8 BOM (Excel compatible) |
+| Aspect | Python | R — Chat Completions | R — Assistants v2 |
+|---|---|---|---|
+| **API** | Chat Completions (`POST /chat/completions`) | Chat Completions (`POST /chat/completions`) | Assistants v2 (`/assistants`, `/threads`, `/runs`) |
+| **Entry script(s)** | `grading_context.py`, `grade_student.py`, `batch_grade.py` | `chat_grading_runner.R` | `oaii_grading_assistant.R`, `oaii_grading_assistant_runner.R` |
+| **Execution model** | Synchronous — one HTTP call per student | Synchronous — one HTTP call per student | Asynchronous — thread created, run started, then polled |
+| **Setup required** | None — stateless | None — stateless | One-time per assignment (file upload + assistant creation) |
+| **Context delivery** | Rubric, solution, starter inlined in every request | Rubric, solution, starter inlined in every request | Files uploaded once; model retrieves chunks via `file_search` |
+| **Caching** | Ephemeral prompt caching on the shared prefix | Ephemeral prompt caching on the shared prefix | Persistent file storage on OpenAI servers |
+| **Structured output** | `response_format={"type": "json_object"}` | `response_format = list(type = "json_object")` | `response_format = list(type = "json_object")` on run object |
+| **Output parsing** | `json.loads()` | `jsonlite::fromJSON()` | `jsonlite::fromJSON()` |
+| **Temperature** | `0.1` | `0.1` | `0.1` |
+| **Model** | `gpt-5.1` | `gpt-5.1` | `gpt-5.1` |
+| **CSV encoding** | UTF-8 | UTF-8 | UTF-8 BOM (Excel compatible) |
+| **Feedback columns** | Per-question (`Q1_feedback`, …) | Per-question (`Q1_feedback`, …) | Concatenated in a single `Comments` column |
 
 ## Trade-offs
 
-The Python pipeline is simpler to operate: there is no setup step, the
-full grading context is always present verbatim in the prompt, and
-`response_format` guarantees well-formed JSON. Ephemeral caching
-amortises the token cost of the shared rubric and solution across the
-batch. The trade-off is context window pressure — rubric, solution,
-starter, and student submission must all fit within a single call — and
-a hard dependency on cache hit rates for cost efficiency at scale.
+**Python** and **R (Chat Completions)** are operationally equivalent — no setup
+step, no server-side state, and every grading run is fully self-contained.
+Ephemeral caching amortises the token cost of the shared rubric and solution
+across the batch. The trade-off is context window pressure: rubric, solution,
+starter, and student submission must all fit within a single call.
 
-The R pipeline offloads grading materials to OpenAI's file storage,
-keeping per-call payloads small. The setup phase (file upload, assistant
-creation) runs automatically on first use and is skipped on subsequent
-runs via a config cache keyed on model name. The cost is operational
-complexity: the two-script workflow and asynchronous polling require
-more infrastructure than the Python approach. Both pipelines now use the
-same model (`gpt-5.1`), temperature (`0.1`), and API-enforced JSON
-output (`response_format = json_object`), so the remaining differences —
-Assistants v2 vs Chat Completions, and file retrieval vs inline context
-— are the variables under study.
+**R (Assistants v2)** offloads grading materials to OpenAI's file storage,
+keeping per-call payloads small. The setup phase runs once per assignment and is
+skipped on subsequent runs if `assistant_config.json` is present and matches the
+current model. The cost is operational complexity: the two-script workflow and
+asynchronous polling require more infrastructure than the Chat Completions
+pipelines.
+
+All three pipelines use the same model (`gpt-5.1`), temperature (`0.1`), and
+API-enforced JSON output (`response_format = json_object`). The variables under
+study are therefore the API surface (Assistants v2 vs Chat Completions) and
+context delivery mechanism (file retrieval vs inline prompt).

--- a/docs/python_pipeline_overview.md
+++ b/docs/python_pipeline_overview.md
@@ -15,8 +15,8 @@ configuration. It calls `load_dotenv()` once on import, reads `LAB_NUMBER` from
 the environment (raising a clear error if absent), and defines all shared
 constants: `MODEL`, `Q_COUNT` (the number of graded questions per lab), and
 resolved file paths for the rubric JSON, starter template, instructor solution,
-and grader instructions — all located in the `assignment/` directory except the
-Python-specific `grader_instructions.txt`, which lives at the project root. The
+and grader instructions — all located in the `assignment/` directory except
+`grader_instructions.txt`, which lives in `Python/`. The
 `build_system_message()` function packages the grader instructions as an OpenAI
 system message. `build_cached_context_messages()` loads the rubric, starter, and
 solution as separate user messages each tagged with

--- a/docs/r_pipeline_overview.md
+++ b/docs/r_pipeline_overview.md
@@ -1,7 +1,17 @@
-# R Grading Pipeline: Technical Overview
+# R Grading Pipelines: Technical Overview
 
-The R grading pipeline automates the evaluation of student Quarto (`.qmd`) lab
-submissions using the OpenAI Assistants API v2. It is implemented across two
+Two independent R pipelines are provided. The **Assistants v2 pipeline**
+uploads grading materials to OpenAI and uses semantic `file_search` for context
+delivery; it is the primary R pipeline compared against Python in the JOSE
+paper. The **Chat Completions pipeline** mirrors the Python approach by inlining
+all context in every request with ephemeral prompt caching.
+
+---
+
+## Assistants v2 Pipeline
+
+The Assistants v2 pipeline automates the evaluation of student Quarto (`.qmd`)
+lab submissions using the OpenAI Assistants API v2. It is implemented across two
 scripts that must be run in sequence: a one-time **setup script**
 (`oaii_grading_assistant.R`) and a **runner script**
 (`oaii_grading_assistant_runner.R`).
@@ -45,3 +55,44 @@ grades and feedback are assembled into a data frame alongside a computed total
 and concatenated comments column. The final results for all students are written
 to `r_lab{N}_grades.csv` with a UTF-8 BOM for Excel compatibility using
 `readr::write_excel_csv()`.
+
+---
+
+## Chat Completions Pipeline
+
+`chat_grading_runner.R` is a stateless, single-phase R pipeline that mirrors
+`Python/grade_student.py` and `Python/batch_grade.py`. No setup step or
+server-side state is required.
+
+### Context Delivery
+
+Grading materials (rubric JSON, starter `.qmd`, instructor solution `.qmd`) are
+read from `R assignments/` and inlined in every API call. Each material is
+wrapped in a `role = "user"` message tagged with
+`cache_control = list(type = "ephemeral")`, matching the Python pipeline's
+prompt-caching strategy exactly. The shared system prompt is read from
+`Python/grader_instructions.txt`.
+
+### Single-Student Grading
+
+`grade_student()` assembles the full message list — system message, three cached
+context messages, and a user message containing the student submission delimited
+by `=== STUDENT_QMD_START/END ===` — and sends a single synchronous POST to
+`/chat/completions` (`gpt-5.1`, `temperature = 0.1`,
+`response_format = json_object`). The response is parsed with
+`jsonlite::fromJSON()`.
+
+### Batch Processing and Output
+
+`main()` walks `R assignments/` for student submission subfolders, calls
+`grade_student()` for each, and writes results to
+`R assignments/r_chat_lab{N}_grades.csv` (UTF-8). Per-student exceptions are
+caught and recorded as error rows; the batch continues regardless. Output
+columns match the Python pipeline: `Student`, `Total`, `OverallComment`,
+`Q1`–`QN`, `Q1_feedback`–`QN_feedback`.
+
+### Shared utilities
+
+`utils.R` provides `safe_num()`, a helper used by both `chat_grading_runner.R`
+and `reliability_test.R` to coerce parsed JSON values to numeric, returning
+`NA_real_` when conversion fails.

--- a/docs/software_documentation.md
+++ b/docs/software_documentation.md
@@ -11,11 +11,12 @@
 3.  [Prerequisites](#3-prerequisites)
 4.  [Installation](#4-installation)
 5.  [Preparing Grading Materials](#5-preparing-grading-materials)
-6.  [Running the R Pipeline](#6-running-the-r-pipeline)
+6.  [Running the R Pipelines](#6-running-the-r-pipelines)
 7.  [Running the Python Pipeline](#7-running-the-python-pipeline)
 8.  [Output Format](#8-output-format)
 9.  [Pipeline Comparison](#9-pipeline-comparison)
 10. [Running Tests](#10-running-tests)
+11. [Reliability Testing](#11-reliability-testing)
 
 ------------------------------------------------------------------------
 
@@ -38,7 +39,11 @@ Both pipelines accept assignments containing any mix of programming questions, o
 .
 ├── R/
 │   ├── oaii_grading_assistant.R         # Setup: upload files, create assistant, save IDs
-│   └── oaii_grading_assistant_runner.R  # Grading: batch loop, poll, parse, write CSV
+│   ├── oaii_grading_assistant_runner.R  # Grading: batch loop, poll, parse, write CSV (Assistants v2)
+│   ├── chat_grading_runner.R            # Grading: Chat Completions pipeline (mirrors Python)
+│   ├── reliability_test.R               # Run grade_student() N times per student; write per-student CSVs
+│   ├── aggregate_results.R              # Aggregate per-student reliability CSVs into comparison summary
+│   └── utils.R                          # Shared helpers (safe_num, etc.)
 │
 ├── Python/
 │   ├── grading_context.py               # Config, shared message builders, prompt caching
@@ -216,11 +221,15 @@ The student ID is extracted from the folder name as the portion after the first 
 
 ------------------------------------------------------------------------
 
-## 6. Running the R Pipeline
+## 6. Running the R Pipelines
 
-The R pipeline runs in two phases. The setup phase is run once per assignment; the grading phase can be re-run at any time.
+Two independent R grading pipelines are provided. The **Assistants v2 pipeline** uploads grading materials to OpenAI and uses `file_search` for context retrieval. The **Chat Completions pipeline** mirrors the Python approach: materials are inlined in every request with ephemeral prompt caching.
 
-### 6.1 Set environment variables
+### 6.1 Assistants v2 pipeline
+
+The Assistants v2 pipeline runs in two phases. The setup phase is run once per assignment; the grading phase can be re-run at any time.
+
+#### 6.1.1 Set environment variables
 
 Add the following to your `.env` or R session:
 
@@ -234,7 +243,7 @@ Or set it before sourcing:
 Sys.setenv(LAB_NUMBER = "9")
 ```
 
-### 6.2 Phase 1 — Setup (run once per assignment)
+#### 6.1.2 Phase 1 — Setup (run once per assignment)
 
 ``` r
 source("R/oaii_grading_assistant.R")
@@ -245,7 +254,7 @@ This performs four steps:
 
 1.  Renders `lab_{N}_solutions.qmd` and `lab_{N}_starter.qmd` to GitHub Flavored Markdown using `quarto::quarto_render()`. Output is written to a temporary file to avoid modifying the source directory.
 2.  Uploads the rubric JSON, rendered solution, and rendered starter to the OpenAI Files API (`purpose = "assistants"`).
-3.  Creates an OpenAI Assistant (`gpt-4.1-mini`) with the `file_search` tool enabled, allowing it to retrieve content from the uploaded files at inference time.
+3.  Creates an OpenAI Assistant (`gpt-5.1`) with the `file_search` tool enabled, allowing it to retrieve content from the uploaded files at inference time.
 4.  Writes the resulting IDs to `assignment/assistant_config.json`:
 
 ``` json
@@ -259,7 +268,7 @@ This performs four steps:
 
 > **Note:** Re-run the setup phase any time the rubric, solution, or starter file changes. New file IDs are needed because the previously uploaded versions remain on OpenAI's servers.
 
-### 6.3 Phase 2 — Grade
+#### 6.1.3 Phase 2 — Grade
 
 Set the path to the student submissions directory and run:
 
@@ -282,6 +291,34 @@ For each student subfolder the runner:
 6.  Extracts the assistant's reply and parses it with `jsonlite::fromJSON()`.
 
 Results are accumulated and written to `assignment/r_lab{N}_grades.csv` (UTF-8 BOM, for Excel compatibility) once all students have been processed.
+
+### 6.2 Chat Completions pipeline
+
+`chat_grading_runner.R` is a second R pipeline that mirrors the Python approach. Grading materials (rubric, starter, solution) are read from `R assignments/` and inlined in every API call with ephemeral prompt caching, keeping the workflow stateless — no setup phase or uploaded files required.
+
+#### 6.2.1 Set environment variables
+
+``` r
+LAB_NUMBER <- 9
+```
+
+`OPENAI_API_KEY` must be set in `.env` or the environment.
+
+#### 6.2.2 Run
+
+``` r
+source("R/chat_grading_runner.R")
+main()
+```
+
+For each student subfolder the runner:
+
+1.  Reads the student's `.qmd` file.
+2.  Assembles a message list: system message (from `Python/grader_instructions.txt`), three cached context messages (rubric, starter, solution each tagged with `cache_control = list(type = "ephemeral")`), and a user message containing the student submission.
+3.  Sends a single synchronous request to `POST /chat/completions` (`gpt-5.1`, `temperature = 0.1`, `response_format = json_object`).
+4.  Parses the reply with `jsonlite::fromJSON()`.
+
+Results are written to `R assignments/r_chat_lab{N}_grades.csv` (UTF-8, with separate `Q*_feedback` columns).
 
 ------------------------------------------------------------------------
 
@@ -382,21 +419,24 @@ If grading fails for an individual student (API timeout, malformed JSON, or miss
 
 ## 9. Pipeline Comparison
 
-| Aspect | Python | R |
-|----|----|----|
-| **API** | Chat Completions | Assistants v2 |
-| **Execution** | Synchronous | Asynchronous with polling |
-| **Setup required** | None | One-time per assignment |
-| **Context delivery** | Inlined in every request | Uploaded once; retrieved via `file_search` |
-| **Caching** | Ephemeral prompt caching | Persistent file storage on OpenAI servers |
-| **Structured output** | `response_format` enforced at API level | `response_format` set on run object |
-| **Output CSV encoding** | UTF-8 | UTF-8 BOM |
-| **Feedback columns** | One column per question (`Q1_feedback`, …) | All feedback concatenated in `Comments` |
-| **Model** | `gpt-5.1` | `gpt-4.1-mini` |
+Three pipelines are available. The primary comparison in the JOSE paper is between the **Python** pipeline and the **R (Assistants v2)** pipeline; the **R (Chat Completions)** pipeline is a direct R port of the Python approach and serves as a bridge between the two.
 
-**Python** is simpler to operate — no setup step, no server-side state, and every grading run is fully self-contained. The full context must fit in a single call, but ephemeral caching keeps token costs manageable across a batch.
+| Aspect | Python | R — Chat Completions | R — Assistants v2 |
+|---|---|---|---|
+| **API** | Chat Completions | Chat Completions | Assistants v2 |
+| **Script(s)** | `grading_context.py`, `grade_student.py`, `batch_grade.py` | `chat_grading_runner.R` | `oaii_grading_assistant.R`, `oaii_grading_assistant_runner.R` |
+| **Execution** | Synchronous | Synchronous | Asynchronous with polling |
+| **Setup required** | None | None | One-time per assignment |
+| **Context delivery** | Inlined in every request | Inlined in every request | Uploaded once; retrieved via `file_search` |
+| **Caching** | Ephemeral prompt caching | Ephemeral prompt caching | Persistent file storage on OpenAI servers |
+| **Structured output** | `response_format = json_object` | `response_format = json_object` | `response_format = json_object` on run object |
+| **Output CSV encoding** | UTF-8 | UTF-8 | UTF-8 BOM |
+| **Feedback columns** | One column per question (`Q1_feedback`, …) | One column per question (`Q1_feedback`, …) | All feedback concatenated in `Comments` |
+| **Model** | `gpt-5.1` | `gpt-5.1` | `gpt-5.1` |
 
-**R** keeps per-call payloads small by offloading grading materials to OpenAI file storage, making repeated grading sessions (e.g. late submissions) cheaper once files are already uploaded. The cost is the two-script workflow and the asynchronous polling logic.
+**Python** and **R (Chat Completions)** are operationally equivalent — stateless, no setup step, same caching strategy. The R Chat Completions runner exists to confirm that the Python pipeline's behaviour is reproducible in native R using the same API surface.
+
+**R (Assistants v2)** offloads grading materials to OpenAI file storage, keeping per-call payloads small. Repeated grading runs (e.g. late submissions) do not re-upload files. The cost is the two-script workflow and the asynchronous polling logic.
 
 ------------------------------------------------------------------------
 
@@ -419,3 +459,52 @@ pytest tests/ --ignore=tests/R
 ```
 
 Tests cover: `load_text()` (UTF-8 reading, `FileNotFoundError`), `build_system_message()` (structure and role), `build_cached_context_messages()` (three messages, ephemeral cache control), and `grade_student_qmd()` (response structure, model name, `response_format`, `FileNotFoundError` on missing submission).
+
+------------------------------------------------------------------------
+
+## 11. Reliability Testing
+
+Reliability testing measures grading variability by running each student submission through a pipeline multiple times with identical inputs and recording the spread of scores across runs.
+
+### 11.1 R reliability test
+
+`R/reliability_test.R` drives repeated grading using the Chat Completions pipeline (`chat_grading_runner.R`). For each student it calls `grade_student()` `N` times and writes one CSV per student containing one row per run.
+
+**Usage:**
+
+``` r
+N <- 10          # number of runs per student (default 10)
+source("R/reliability_test.R")
+```
+
+Re-running the script **appends** new runs to existing CSVs with continuous run numbering, so running it ten times with `N = 10` accumulates 100 rows per student.
+
+**Output files** are written beside the student submission folders:
+
+```
+{directory_path}/{folder_name}_grades.csv
+```
+
+e.g. `R assignments/lab-9_student_high_grades.csv`
+
+Each CSV has columns: `Run`, `Total`, `OverallComment`, `Q1`–`QN`, `Q1_feedback`–`QN_feedback`.
+
+### 11.2 Aggregating results
+
+`R/aggregate_results.R` reads the per-student reliability CSVs produced by both the Python and R pipelines and computes mean and standard deviation for each score column, writing a summary CSV with two rows per student (Python then R), separated by blank rows.
+
+**Prerequisites:**
+
+- R per-student CSVs in `R assignments/` matching `lab-{N}_*_grades.csv`
+- Python per-student CSVs in `{BASE_LAB_DIR}/lab-{N}/` with matching names
+- `BASE_LAB_DIR` environment variable set
+
+**Usage:**
+
+``` r
+source("R/aggregate_results.R")
+```
+
+**Output:** `assignment/comparison_summary.csv`
+
+Numeric columns are formatted as `mean (sd)` (e.g. `4.6 (0.52)`). The question columns (`Q1`, `Q2`, …) are detected automatically from the data — no hardcoded count required.


### PR DESCRIPTION
- Add chat_grading_runner.R, reliability_test.R, aggregate_results.R, and utils.R to repo structure and all relevant docs
- Fix model name gpt-4.1-mini → gpt-5.1 in software_documentation.md
- Expand pipeline comparison to 3-way table (Python, R Chat Completions, R Assistants v2) across software_documentation.md and pipeline_comparison.md
- Add §11 Reliability Testing covering reliability_test.R and aggregate_results.R
- Add Chat Completions pipeline section to r_pipeline_overview.md
- Update CI syntax check row to list all 6 R files now covered
- Fix grader_instructions.txt path in python_pipeline_overview.md