### PR TITLE
Add Python test coverage for batch grading and reliability scripts

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -3,7 +3,7 @@ Root conftest.py — loaded by pytest before any test module.
 
 Sets the environment variables that grading_context.py validates at import
 time, then calls grading_context.configure() so that lab-specific paths are
-resolved before any test runs.  Using os.environ.setdefault ensures
+resolved before any test runs. Using os.environ.setdefault ensures
 user-supplied values (e.g. from a real .env) are not overwritten when running
 locally.
 
@@ -15,6 +15,8 @@ from the Python/ directory.
 import os
 import sys
 from pathlib import Path
+
+import pytest
 
 # Make the Python/ source directory importable from the test suite
 sys.path.insert(0, str(Path(__file__).parent / "Python"))
@@ -29,3 +31,13 @@ os.environ.setdefault(
 
 import grading_context  # noqa: E402 — must come after env vars are set
 grading_context.configure(9)
+
+
+@pytest.fixture(autouse=True)
+def reset_grading_context():
+    """Restore the default repo-backed grading context after each test."""
+    grading_context.BASE_LAB_DIR = Path(os.environ["BASE_LAB_DIR"])
+    grading_context.configure(9)
+    yield
+    grading_context.BASE_LAB_DIR = Path(os.environ["BASE_LAB_DIR"])
+    grading_context.configure(9)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,27 +1,9 @@
 # =============================================================================
-# Python packages (pip install -r requirements.txt)
+# Python runtime packages (portable pip install -r requirements.txt)
+# Keep this file free of machine-specific paths from conda exports.
 # =============================================================================
-openai
-python-dotenv
-annotated-types==0.7.0
-anyio==4.13.0
-certifi==2026.2.25
-distro==1.9.0
-h11==0.16.0
-httpcore==1.0.9
-httpx==0.28.1
-idna==3.11
-jiter==0.13.0
 openai==2.30.0
-packaging @ file:///opt/miniconda3/conda-bld/packaging_1761049079066/work
-pydantic==2.12.5
-pydantic_core==2.41.5
 python-dotenv==1.2.2
-ruff==0.15.8
-sniffio==1.3.1
-tqdm==4.67.3
-typing-inspection==0.4.2
-typing_extensions==4.15.0
 
 # =============================================================================
 # R packages

--- a/tests/test_batch_grade.py
+++ b/tests/test_batch_grade.py
@@ -1,0 +1,91 @@
+"""
+Unit tests for batch_grade.py.
+
+These tests mock the per-student grading call so we can verify folder
+discovery, CSV writing, student ID extraction, and error-row handling
+without making any API requests.
+"""
+import csv
+from pathlib import Path
+
+import batch_grade
+import grading_context
+
+
+def _make_student_submission(base_dir: Path, folder_name: str, lab_number: int = 9) -> Path:
+    student_dir = base_dir / f"lab-{lab_number}" / folder_name
+    student_dir.mkdir(parents=True)
+    qmd_path = student_dir / f"lab-{lab_number}.qmd"
+    qmd_path.write_text("# Submission", encoding="utf-8")
+    return qmd_path
+
+
+def _mock_grade_payload(total: int) -> dict:
+    questions = {
+        f"Q{i}": {"grade": i, "feedback": f"Feedback for Q{i}"}
+        for i in range(1, grading_context.Q_COUNT + 1)
+    }
+    return {
+        "questions": questions,
+        "total": total,
+        "overall_comment": "Mocked overall comment.",
+    }
+
+
+def test_main_writes_expected_csv_for_multiple_students(tmp_path, monkeypatch):
+    base_dir = tmp_path / "assignment"
+    _make_student_submission(base_dir, "lab-9_student_alpha")
+    _make_student_submission(base_dir, "lab-9_student_beta")
+
+    monkeypatch.setattr(grading_context, "BASE_LAB_DIR", base_dir)
+
+    totals_by_file = {
+        "lab-9_student_alpha": 55,
+        "lab-9_student_beta": 42,
+    }
+
+    def fake_grade_student_qmd(path: Path) -> dict:
+        return _mock_grade_payload(totals_by_file[path.parent.name])
+
+    monkeypatch.setattr(batch_grade, "grade_student_qmd", fake_grade_student_qmd)
+
+    batch_grade.main(9)
+
+    output_csv = base_dir / "lab-9" / "lab9_grades.csv"
+    assert output_csv.exists()
+
+    with output_csv.open(newline="", encoding="utf-8") as f:
+        rows = list(csv.DictReader(f))
+
+    assert [row["Student"] for row in rows] == ["student_alpha", "student_beta"]
+    assert [row["Total"] for row in rows] == ["55", "42"]
+    assert rows[0]["OverallComment"] == "Mocked overall comment."
+    assert rows[0]["Q1"] == "1"
+    assert rows[0]["Q10_feedback"] == "Feedback for Q10"
+
+
+def test_main_records_error_row_when_student_grading_fails(tmp_path, monkeypatch):
+    base_dir = tmp_path / "assignment"
+    _make_student_submission(base_dir, "lab-9_student_alpha")
+    _make_student_submission(base_dir, "lab-9_student_beta")
+
+    monkeypatch.setattr(grading_context, "BASE_LAB_DIR", base_dir)
+
+    def fake_grade_student_qmd(path: Path) -> dict:
+        if path.parent.name == "lab-9_student_beta":
+            raise RuntimeError("simulated API failure")
+        return _mock_grade_payload(55)
+
+    monkeypatch.setattr(batch_grade, "grade_student_qmd", fake_grade_student_qmd)
+
+    batch_grade.main(9)
+
+    output_csv = base_dir / "lab-9" / "lab9_grades.csv"
+    with output_csv.open(newline="", encoding="utf-8") as f:
+        rows = list(csv.DictReader(f))
+
+    error_row = next(row for row in rows if row["Student"] == "student_beta")
+    assert error_row["Total"] == ""
+    assert error_row["OverallComment"] == "Error: simulated API failure"
+    assert error_row["Q1"] == ""
+    assert error_row["Q10_feedback"] == ""

--- a/tests/test_reliability_test.py
+++ b/tests/test_reliability_test.py
@@ -1,0 +1,89 @@
+"""
+Unit tests for Python/reliability_test.py.
+
+These tests mock the grading call so we can verify run-offset detection,
+per-run error handling, and CSV append behaviour without making any API
+requests.
+"""
+import csv
+
+import grading_context
+import reliability_test
+
+
+def _make_student_submission(base_dir, folder_name: str, lab_number: int = 9):
+    student_dir = base_dir / f"lab-{lab_number}" / folder_name
+    student_dir.mkdir(parents=True)
+    qmd_path = student_dir / f"lab-{lab_number}.qmd"
+    qmd_path.write_text("# Submission", encoding="utf-8")
+    return qmd_path
+
+
+def _mock_grade_payload(total: int) -> dict:
+    questions = {
+        f"Q{i}": {"grade": i, "feedback": f"Feedback for Q{i}"}
+        for i in range(1, grading_context.Q_COUNT + 1)
+    }
+    return {
+        "questions": questions,
+        "total": total,
+        "overall_comment": "Mocked overall comment.",
+    }
+
+
+def test_get_run_offset_returns_zero_for_missing_csv(tmp_path):
+    assert reliability_test._get_run_offset(tmp_path / "missing.csv") == 0
+
+
+def test_get_run_offset_returns_highest_existing_run_number(tmp_path):
+    csv_path = tmp_path / "runs.csv"
+    csv_path.write_text("Run,Total\n1,10\n3,11\n2,9\n", encoding="utf-8")
+
+    assert reliability_test._get_run_offset(csv_path) == 3
+
+
+def test_grade_n_times_records_error_rows_without_aborting(tmp_path, monkeypatch):
+    student_path = tmp_path / "lab-9.qmd"
+    student_path.write_text("# Submission", encoding="utf-8")
+
+    calls = {"count": 0}
+
+    def fake_grade_student_qmd(_path):
+        calls["count"] += 1
+        if calls["count"] == 2:
+            raise RuntimeError("simulated API failure")
+        return _mock_grade_payload(27)
+
+    monkeypatch.setattr(reliability_test, "grade_student_qmd", fake_grade_student_qmd)
+
+    rows = reliability_test.grade_n_times(student_path, n_runs=3, run_offset=4)
+
+    assert [row["Run"] for row in rows] == [5, 6, 7]
+    assert rows[0]["Total"] == 27
+    assert rows[1]["Total"] is None
+    assert rows[1]["OverallComment"] == "Error: simulated API failure"
+    assert rows[2]["Total"] == 27
+
+
+def test_main_appends_runs_with_continuous_numbering(tmp_path, monkeypatch):
+    base_dir = tmp_path / "assignment"
+    _make_student_submission(base_dir, "lab-9_student_alpha")
+
+    monkeypatch.setattr(grading_context, "BASE_LAB_DIR", base_dir)
+    monkeypatch.setattr(reliability_test.grading_context, "BASE_LAB_DIR", base_dir)
+    monkeypatch.setattr(
+        reliability_test,
+        "grade_student_qmd",
+        lambda _path: _mock_grade_payload(19),
+    )
+
+    reliability_test.main(n_runs=2, lab_number=9)
+    reliability_test.main(n_runs=2, lab_number=9)
+
+    output_csv = base_dir / "lab-9" / "lab-9_student_alpha_grades.csv"
+    with output_csv.open(newline="", encoding="utf-8") as f:
+        rows = list(csv.DictReader(f))
+
+    assert [row["Run"] for row in rows] == ["1", "2", "3", "4"]
+    assert all(row["Total"] == "19" for row in rows)
+    assert all(row["Q1_feedback"] == "Feedback for Q1" for row in rows)


### PR DESCRIPTION
## What this PR does

Adds focused Python test coverage for the recently added batch grading and reliability workflows.

## Changes

- adds tests for `Python/batch_grade.py`
  - verifies CSV output for multiple students
  - verifies error-row handling when one student grading call fails
- adds tests for `Python/reliability_test.py`
  - verifies run-offset detection
  - verifies per-run exception handling
  - verifies append behavior and continuous run numbering
- adds an autouse fixture in `conftest.py` to reset shared `grading_context` state between tests

## Verification

- Ran:
  - `python -m pytest tests/test_batch_grade.py tests/test_reliability_test.py tests/test_grade_student.py tests/test_grading_context.py -v --basetemp .pytest_tmp`

## Why this matters

These tests improve confidence in core grading workflows and make the repo stronger for review and reproducibility.
