### PR TITLE
Clean up Python tooling config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,9 +21,8 @@ dev = [
 [tool.setuptools.packages.find]
 where = ["Python"]
 
-[tool.ruff]
+[tool.ruff.lint]
 select = ["F"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
-ignore = ["tests/R"]


### PR DESCRIPTION
## What this PR does

Cleans up Python tooling configuration in `pyproject.toml`.

## Changes

- moves Ruff settings to the current `[tool.ruff.lint]` section
- removes the invalid pytest `ignore` config entry that produced a warning

## Verification

- `python -m ruff check --select F Python/ tests/ conftest.py`
- `python -m pytest tests/ --ignore=tests/R -v --basetemp .pytest_tmp`

## Why this matters

This removes noisy tooling warnings and keeps the Python test/lint configuration aligned with current tool behavior.
