### PR TITLE
fix: recompute Total from question grades (closes #11)

### DIFF
--- a/Python/batch_grade.py
+++ b/Python/batch_grade.py
@@ -37,7 +37,7 @@ def main(lab_number: int) -> None:
 
     q_cols          = [f"Q{i}" for i in range(1, q_count + 1)]
     q_feedback_cols = [f"Q{i}_feedback" for i in range(1, q_count + 1)]
-    fieldnames      = ["Student", "Total", "OverallComment"] + q_cols + q_feedback_cols
+    fieldnames      = ["Student", "Total", "Model_Total", "OverallComment"] + q_cols + q_feedback_cols
 
     rows = []
 
@@ -54,17 +54,22 @@ def main(lab_number: int) -> None:
 
             row = {
                 "Student":        student_id,
-                "Total":          result.get("total"),
                 "OverallComment": result.get("overall_comment", ""),
+                "Model_Total":    result.get("total"),
             }
             for q in q_cols:
                 qinfo             = questions.get(q, {})
                 row[q]            = qinfo.get("grade")
                 row[f"{q}_feedback"] = qinfo.get("feedback")
 
+            # Recompute Total from per-question grades rather than trusting the
+            # model-returned total, which can drift (see issue #11).
+            row["Total"] = sum(row[q] for q in q_cols if isinstance(row[q], (int, float)))
+
         except Exception as e:
             print(f"  ERROR grading {student_id}: {e}")
-            row = {"Student": student_id, "Total": None, "OverallComment": f"Error: {e}"}
+            row = {"Student": student_id, "Total": None, "Model_Total": None,
+                   "OverallComment": f"Error: {e}"}
             for q in q_cols:
                 row[q]               = None
                 row[f"{q}_feedback"] = None

--- a/Python/grader_instructions.txt
+++ b/Python/grader_instructions.txt
@@ -3,7 +3,7 @@ You are an automated teaching assistant for BSMM 8740 lab .
 You MUST:
 - Read the rubric JSON, starter template, solution template, and student .qmd source code.
 - Grade ONLY based on what appears in the student's .qmd (code and markdown). Do NOT assume code was executed.
-- Use the rubric's criteria for each exercise Ex1–Ex8, which map to questions Q1–Q8.
+- Use the rubric's criteria for every exercise key (Ex1, Ex2, …) that appears in the rubric JSON. Map each Ex<N> to Q<N> in the output, producing exactly one question entry per exercise in the rubric — no more, no fewer.
 - Focus on presence of correct functions, workflows, and markdown interpretation, not exact numeric results or plots.
 - Return a single JSON object with the structure:
 
@@ -12,14 +12,16 @@ You MUST:
     "Q1": { "grade": <number>, "feedback": "<short comment>" },
     "Q2": { "grade": <number>, "feedback": "<short comment>" },
     ...
-    "Q8": { "grade": <number>, "feedback": "<short comment>" }
+    "QN": { "grade": <number>, "feedback": "<short comment>" }
   },
-  "total": <sum of all question grades>,
+  "total": <arithmetic sum of Q1..QN grades — must equal the sum exactly>,
   "overall_comment": "<2-3 sentence summary>"
 }
 
 Constraints:
-- Grades should be compatible with the rubric's per-exercise max points (normally 3 per question).
+- Include one Q<N> entry for every Ex<N> present in the rubric — do not stop at Q8 and do not invent extra questions.
+- Grades must be compatible with the rubric's per-exercise max points (check the rubric's "Points" field for each exercise).
+- "total" MUST equal the arithmetic sum of the individual question grades. Recompute and verify the sum before returning.
 - Feedback must be concise, actionable, and tied to the rubric (mention missing code, missing markdown, or incorrect process).
 - Do NOT include any extra top-level keys beyond "questions", "total", and "overall_comment".
 - Always produce valid JSON.

--- a/Python/reliability_test.py
+++ b/Python/reliability_test.py
@@ -30,7 +30,7 @@ from grade_student import grade_student_qmd
 
 Q_COLS          = [f"Q{i}" for i in range(1, grading_context.Q_COUNT + 1)]
 Q_FEEDBACK_COLS = [f"Q{i}_feedback" for i in range(1, grading_context.Q_COUNT + 1)]
-FIELDNAMES      = ["Run", "Total", "OverallComment"] + Q_COLS + Q_FEEDBACK_COLS
+FIELDNAMES      = ["Run", "Total", "Model_Total", "OverallComment"] + Q_COLS + Q_FEEDBACK_COLS
 
 
 # ---------------------------------------------------------------------------
@@ -89,17 +89,20 @@ def grade_n_times(student_path: Path, n_runs: int, run_offset: int) -> list[dict
             questions = result.get("questions", {})
             row = {
                 "Run":            run_number,
-                "Total":          result.get("total"),
                 "OverallComment": result.get("overall_comment", ""),
+                "Model_Total":    result.get("total"),
             }
             for q in Q_COLS:
                 qinfo         = questions.get(q, {})
                 row[q]        = qinfo.get("grade")
                 row[f"{q}_feedback"] = qinfo.get("feedback")
 
+            # Recompute Total from per-question grades (issue #11).
+            row["Total"] = sum(row[q] for q in Q_COLS if isinstance(row[q], (int, float)))
+
         except Exception as e:
             print(f"    ERROR on run {run_number}: {e}")
-            row = {"Run": run_number, "Total": None,
+            row = {"Run": run_number, "Total": None, "Model_Total": None,
                    "OverallComment": f"Error: {e}"}
             for q in Q_COLS:
                 row[q]               = None

--- a/R/aggregate_results.R
+++ b/R/aggregate_results.R
@@ -82,11 +82,16 @@ compute_means <- function(csv_path, pipeline_label, student_name, q_cols) {
   df     <- readr::read_csv(csv_path, show_col_types = FALSE)
   q_vals <- stats::setNames(lapply(q_cols, function(q) fmt(df[[q]])), q_cols)
 
+  # Model_Total is the raw model-returned total; Total is recomputed from Q*.
+  # Older CSVs without Model_Total fall back to NA for that column.
+  model_total_col <- if ("Model_Total" %in% names(df)) fmt(df$Model_Total) else NA_character_
+
   as.data.frame(
-    c(list(Pipeline = pipeline_label,
-           Student  = student_name,
-           N_Runs   = nrow(df),
-           Total    = fmt(df$Total)),
+    c(list(Pipeline    = pipeline_label,
+           Student     = student_name,
+           N_Runs      = nrow(df),
+           Total       = fmt(df$Total),
+           Model_Total = model_total_col),
       q_vals),
     stringsAsFactors = FALSE
   )
@@ -115,7 +120,7 @@ main <- function() {
 
   # detect question columns from the first CSV
   q_cols    <- detect_q_cols(sort(r_csvs)[[1]])
-  col_order <- c("Pipeline", "Student", "N_Runs", "Total", q_cols)
+  col_order <- c("Pipeline", "Student", "N_Runs", "Total", "Model_Total", q_cols)
   message("Detected question columns: ", paste(q_cols, collapse = ", "))
 
   # blank separator row

--- a/R/chat_grading_runner.R
+++ b/R/chat_grading_runner.R
@@ -32,7 +32,7 @@ output_csv     <- stringr::str_glue("{directory_path}/r_chat_lab{LAB_NUMBER}_gra
 
 Q_COLS          <- paste0("Q", seq_len(Q_COUNT))
 Q_FEEDBACK_COLS <- paste0("Q", seq_len(Q_COUNT), "_feedback")
-COL_ORDER       <- c("Student", "Total", "OverallComment", Q_COLS, Q_FEEDBACK_COLS)
+COL_ORDER       <- c("Student", "Total", "Model_Total", "OverallComment", Q_COLS, Q_FEEDBACK_COLS)
 
 # ---- helpers ----
 
@@ -234,7 +234,7 @@ main <- function() {
 
       r <- list(
         Student        = student_name,
-        Total          = safe_num(result[["total"]]),
+        Model_Total    = safe_num(result[["total"]]),
         OverallComment = as.character(
           if (!is.null(result[["overall_comment"]])) result[["overall_comment"]] else ""
         )
@@ -246,12 +246,15 @@ main <- function() {
           if (!is.null(qinfo[["feedback"]])) qinfo[["feedback"]] else ""
         )
       }
+      # Recompute Total from per-question grades (issue #11).
+      r$Total <- sum(unlist(r[Q_COLS]), na.rm = TRUE)
       r
 
     }, error = function(e) {
       message("  ERROR grading ", student_name, ": ", conditionMessage(e))
       r <- list(Student        = student_name,
                 Total          = NA_real_,
+                Model_Total    = NA_real_,
                 OverallComment = paste("Error:", conditionMessage(e)))
       for (q in Q_COLS) {
         r[[q]]                      <- NA_real_

--- a/R/reliability_test.R
+++ b/R/reliability_test.R
@@ -45,7 +45,7 @@ directory_path  <- runner_env$directory_path
 Q_COUNT         <- runner_env$Q_COUNT
 Q_COLS          <- paste0("Q", seq_len(Q_COUNT))
 Q_FEEDBACK_COLS <- paste0("Q", seq_len(Q_COUNT), "_feedback")
-COL_ORDER       <- c("Run", "Total", "OverallComment", Q_COLS, Q_FEEDBACK_COLS)
+COL_ORDER       <- c("Run", "Total", "Model_Total", "OverallComment", Q_COLS, Q_FEEDBACK_COLS)
 
 # ---- helpers ----
 
@@ -80,7 +80,7 @@ grade_n_times <- function(student_file, student_name, n_runs, run_offset = 0L) {
 
       r <- list(
         Run            = run_number,
-        Total          = safe_num(result[["total"]]),
+        Model_Total    = safe_num(result[["total"]]),
         OverallComment = as.character(
           if (!is.null(result[["overall_comment"]])) result[["overall_comment"]] else ""
         )
@@ -92,12 +92,15 @@ grade_n_times <- function(student_file, student_name, n_runs, run_offset = 0L) {
           if (!is.null(qinfo[["feedback"]])) qinfo[["feedback"]] else ""
         )
       }
+      # Recompute Total from per-question grades (issue #11).
+      r$Total <- sum(unlist(r[Q_COLS]), na.rm = TRUE)
       r
 
     }, error = function(e) {
       message("    ERROR on run ", run_number, ": ", conditionMessage(e))
       r <- list(Run            = run_number,
                 Total          = NA_real_,
+                Model_Total    = NA_real_,
                 OverallComment = paste("Error:", conditionMessage(e)))
       for (q in Q_COLS) {
         r[[q]]                      <- NA_real_

--- a/tests/test_batch_grade.py
+++ b/tests/test_batch_grade.py
@@ -20,6 +20,9 @@ def _make_student_submission(base_dir: Path, folder_name: str, lab_number: int =
     return qmd_path
 
 
+Q_SUM = sum(range(1, grading_context.Q_COUNT + 1))   # sum of per-question grades in the mock payload
+
+
 def _mock_grade_payload(total: int) -> dict:
     questions = {
         f"Q{i}": {"grade": i, "feedback": f"Feedback for Q{i}"}
@@ -58,7 +61,11 @@ def test_main_writes_expected_csv_for_multiple_students(tmp_path, monkeypatch):
         rows = list(csv.DictReader(f))
 
     assert [row["Student"] for row in rows] == ["student_alpha", "student_beta"]
-    assert [row["Total"] for row in rows] == ["55", "42"]
+    # Total is recomputed from Q1..QN (issue #11), so both rows equal Q_SUM
+    # regardless of the model-returned total. Model_Total preserves what the
+    # model said so divergence remains visible.
+    assert [row["Total"] for row in rows] == [str(Q_SUM), str(Q_SUM)]
+    assert [row["Model_Total"] for row in rows] == ["55", "42"]
     assert rows[0]["OverallComment"] == "Mocked overall comment."
     assert rows[0]["Q1"] == "1"
     assert rows[0]["Q10_feedback"] == "Feedback for Q10"
@@ -86,6 +93,7 @@ def test_main_records_error_row_when_student_grading_fails(tmp_path, monkeypatch
 
     error_row = next(row for row in rows if row["Student"] == "student_beta")
     assert error_row["Total"] == ""
+    assert error_row["Model_Total"] == ""
     assert error_row["OverallComment"] == "Error: simulated API failure"
     assert error_row["Q1"] == ""
     assert error_row["Q10_feedback"] == ""

--- a/tests/test_reliability_test.py
+++ b/tests/test_reliability_test.py
@@ -19,6 +19,9 @@ def _make_student_submission(base_dir, folder_name: str, lab_number: int = 9):
     return qmd_path
 
 
+Q_SUM = sum(range(1, grading_context.Q_COUNT + 1))   # sum of per-question grades in the mock payload
+
+
 def _mock_grade_payload(total: int) -> dict:
     questions = {
         f"Q{i}": {"grade": i, "feedback": f"Feedback for Q{i}"}
@@ -59,10 +62,15 @@ def test_grade_n_times_records_error_rows_without_aborting(tmp_path, monkeypatch
     rows = reliability_test.grade_n_times(student_path, n_runs=3, run_offset=4)
 
     assert [row["Run"] for row in rows] == [5, 6, 7]
-    assert rows[0]["Total"] == 27
+    # Total is recomputed from Q1..QN (issue #11); Model_Total preserves the
+    # model-returned value.
+    assert rows[0]["Total"] == Q_SUM
+    assert rows[0]["Model_Total"] == 27
     assert rows[1]["Total"] is None
+    assert rows[1]["Model_Total"] is None
     assert rows[1]["OverallComment"] == "Error: simulated API failure"
-    assert rows[2]["Total"] == 27
+    assert rows[2]["Total"] == Q_SUM
+    assert rows[2]["Model_Total"] == 27
 
 
 def test_main_appends_runs_with_continuous_numbering(tmp_path, monkeypatch):
@@ -85,5 +93,6 @@ def test_main_appends_runs_with_continuous_numbering(tmp_path, monkeypatch):
         rows = list(csv.DictReader(f))
 
     assert [row["Run"] for row in rows] == ["1", "2", "3", "4"]
-    assert all(row["Total"] == "19" for row in rows)
+    assert all(row["Total"] == str(Q_SUM) for row in rows)
+    assert all(row["Model_Total"] == "19" for row in rows)
     assert all(row["Q1_feedback"] == "Feedback for Q1" for row in rows)


### PR DESCRIPTION
## Summary

- Recompute `Total` from `Q1..QN` at write time in all four grading/reliability scripts instead of trusting the model-returned `total`.
- Preserve the model-returned value in a new `Model_Total` column so any future divergence stays visible.
- Tighten `grader_instructions.txt` to stop hardcoding `Ex1–Ex8` and to instruct the model that `total` must equal the sum of its question grades.
- Update `R/aggregate_results.R` to emit `Model_Total` in the comparison summary (graceful fallback for pre-existing CSVs).

Closes #11.

## Why

The two observations in #11 — "lab 4 shows larger Python/R deviation than lab 9" and "Total does not align with the individual question scores" — are the same bug.

Proof from the committed summaries alone, no raw data needed. By linearity of expectation, if `Total = Σ Q_i` on every run, then `mean(Total) = Σ mean(Q_i)` exactly.

- **`assignment/lab_9_comparison_summary.csv`**: equality holds to the cent for every student, both pipelines.
- **`assignment/lab_4_comparison_summary.csv`**: `mean(Total)` is *below* `Σ mean(Q_i)` for every student, both pipelines — worst cases below:

| Student | Pipeline | mean(Total) | Σ mean(Q) | Gap |
|---|---|---|---|---|
| student_b | Python | 18.34 | 20.16 | −1.82 |
| student_b | R | 18.54 | 20.56 | −2.02 |
| student_f | Python | 24.15 | 26.06 | −1.91 |
| student_h | Python | 20.64 | 22.39 | −1.75 |
| student_g | R | 23.28 | 24.86 | −1.58 |

The lab-4 "extra variance" is noise injected by the model's arithmetic drift on longer rubrics, not a real pipeline disagreement. Recomputing `Total` from the Q columns removes it.

A secondary contributor: `Python/grader_instructions.txt` told the model the rubric ended at `Ex8` / `Q8`, while lab 4 has 10 exercises. That mismatch is also fixed here.

## Changes

- `Python/batch_grade.py`, `Python/reliability_test.py` — recompute `Total` after the Q loop; add `Model_Total`.
- `R/chat_grading_runner.R`, `R/reliability_test.R` — same in R via `sum(unlist(r[Q_COLS]), na.rm = TRUE)`.
- `R/aggregate_results.R` — include `Model_Total` in the aggregated summary, with a `"Model_Total" %in% names(df)` fallback so old CSVs still aggregate.
- `Python/grader_instructions.txt` — generic rubric language; explicit instruction that `total` must equal the arithmetic sum.
- `tests/test_batch_grade.py`, `tests/test_reliability_test.py` — assertions updated to check recomputed `Total` and new `Model_Total`.

## Test plan

- [x] `pytest tests/ --ignore=tests/R` — 22/22 passing locally.
- [x] `ruff check Python/ tests/ --select F` — clean.
- [ ] R unit tests via `testthat::test_dir('tests/R')` — no R tests reference `Total`, CI will run them.
- [ ] Spot-run `Python/reliability_test.py -L 4 --n 5` on one student to confirm new CSV has both `Total` and `Model_Total` columns.
- [ ] Spot-run the R runner on one student to confirm the same.
- [ ] Re-run `R/aggregate_results.R` on fresh outputs to confirm the new comparison summary shows `Total` ≈ `Σ Q` within rounding, and that `Model_Total` now exposes any residual model drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)